### PR TITLE
escape 'if' in command.dhall

### DIFF
--- a/command.dhall
+++ b/command.dhall
@@ -19,7 +19,7 @@ let Command =
           , concurrency_group : Optional Text
           , depends_on : Optional (List Text)
           , env : Optional (Map Text Text)
-          , if : Optional Text
+          , `if` : Optional Text
           , key : Optional Text
           , label : Optional Text
           , parallelism : Optional Natural
@@ -39,7 +39,7 @@ let Command =
         , concurrency_group = None Text
         , depends_on = None (List Text)
         , env = None (Map Text Text)
-        , if = None Text
+        , `if` = None Text
         , key = None Text
         , label = None Text
         , parallelism = None Natural


### PR DESCRIPTION
Before this change, I was seeing: 

```shell
~/dev/go/src/github.com/ggilmore/buildkite.dhall escape*
❯ dhall --version                                                                                                                                                          11:00:15
1.35.0
~/dev/go/src/github.com/ggilmore/buildkite.dhall escape*
❯ dhall --file command.dhall                                                                                                                                               11:00:25
dhall:
Error: Invalid input

command.dhall:22:13:
   |
22 |           , if : Optional Text
   |             ^
unexpected 'i'
expecting whitespace or }
```